### PR TITLE
add windows shell command relative path token %cd%

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ cd [your project]
 docker run -it --rm --name spfx-helloworld -v ${PWD}:/usr/app/spfx -p 5432:5432 -p 4321:4321 -p 35729:35729 waldekm/spfx
 ```
 
-- In other shells on Windows (assumes that your project is at `C:\projects\spfx-helloworld`)
+- In other shells on Windows
 
 ```cmd
-cd \projects\spfx-helloworld
-docker run -it --rm --name spfx-helloworld -v /c/projects/spfx-helloworld:/usr/app/spfx -p 5432:5432 -p 4321:4321 -p 35729:35729 waldekm/spfx
+cd [your project]
+docker run -it --rm --name spfx-helloworld -v %cd%:/usr/app/spfx -p 5432:5432 -p 4321:4321 -p 35729:35729 waldekm/spfx
 ```
 
 After the container started you can work with it the same way you would work with SharePoint Framework installed on your host. To create a new SharePoint Framework project in the container command line execute:


### PR DESCRIPTION
Added %cd% token for windows shell to have curent relative path automatically inserted in the command, like the bash and PS examples.