### PR TITLE
Added support for VS Code Remote Development

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,29 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+    // "See https://aka.ms/vscode-remote/devcontainer.json for format details."
+    "name": "Node with SPFx",
+
+    // "Sets the run context to one level up instead of the .devcontainer folder.
+    "context": "..",
+
+    // "Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename."
+    "dockerFile": "Dockerfile",    
+    
+    // "Use the optional 'appPort' property to expose ports not already in your Dockerfile"
+    "appPort": [
+        5432,
+        4321,
+        35729
+    ],
+    
+    // "Add any extensions you want auto-installed here."
+    "extensions": [],
+
+    // "The optional 'runArgs' property can be used to specify Docker CLI arguments to use when the container."
+    // "is started. If you install the Docker CE CLI in your container, the runArgs list below will lets you interact"
+    // "with your host's Docker service from inside the container. See the docker-in-docker and docker-in-docker"
+    // "definitions for details."
+    "runArgs": [
+        "-u", "spfx"
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,50 @@
+#-------------------------------------------------------------------------------------------------------------
+# VS CODE REMOTE (marked VSCR) sections are:
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
 FROM node:10.15.3
+ARG USERNAME=spfx
 
 EXPOSE 5432 4321 35729
 
-RUN npm i -g gulp@3 yo @microsoft/generator-sharepoint@1.8.2
+# VSCR - Configure apt
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1
 
-VOLUME /usr/app/spfx
-WORKDIR /usr/app/spfx
-RUN useradd --create-home --shell /bin/bash spfx && \
-    usermod -aG sudo spfx && \
-    chown -R spfx:spfx /usr/app/spfx
+# VSCR - Verify git and needed tools are installed
+RUN apt-get install -y git procps
 
-USER spfx
+# VSCR - Remove outdated yarn from /opt and install via package 
+# so it can be easily updated via apt-get upgrade yarn
+RUN rm -rf /opt/yarn-* \
+    && rm -f /usr/local/bin/yarn \
+    && rm -f /usr/local/bin/yarnpkg \
+    && apt-get install -y curl apt-transport-https lsb-release \
+    && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
+    && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends yarn
+    
+# VSCR - Install eslint
+RUN npm install -g eslint
 
-CMD /bin/bash
+# VSCR - Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install SPFx required modules
+RUN npm i -g gulp@4 yo @microsoft/generator-sharepoint@1.8.2
+
+# Create User
+RUN echo $USERNAME \
+    && useradd --create-home --shell /bin/bash $USERNAME \
+    && usermod -aG sudo $USERNAME
+
+ENV HOME /home/$USERNAME
+ENV DEBIAN_FRONTEND=dialog
+
+USER $USERNAME


### PR DESCRIPTION
Hi Waldek,

**Context:**

- https://code.visualstudio.com/docs/remote/remote-overview

**Changes:**

- I started from the "node" sample template
  - https://github.com/microsoft/vscode-remote-try-node/blob/master/.devcontainer/Dockerfile
- I merged with the docker-spfx template
- I created the .devcontainer.json 
  - Added ports to map
  - Added user spfx 

**Tested on:**

  - Windows 10 1903
  - VS Code 1.35.0-insider (user setup)
  - Docker Desktop 2.0.4.1 (edge)

Feel free to reject and add in a separate folder as you see fit.

Christian D.