### PR TITLE
New SPFx Version (1.11.0), New Node Base Image and Updated Rigged Line Numbers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:10.18.1
+FROM node:10.22.0
 
 EXPOSE 5432 4321 35729
 
-RUN npm i -g gulp@3 yo @microsoft/generator-sharepoint@1.10.0
+RUN npm i -g gulp@3 yo @microsoft/generator-sharepoint@1.11.0
 
 VOLUME /usr/app/spfx
 WORKDIR /usr/app/spfx

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When using the container with SharePoint Framework >=v1.6.0 on Windows, you can'
 }
 ```
 
-Then, open `node_modules\@microsoft\sp-build-web\lib\SPWebBuildRig.js` and change lines 83-85 from:
+Then, open `node_modules\@microsoft\sp-build-web\lib\SPWebBuildRig.js` and change lines 96-98 from:
 
 ```js
 spBuildCoreTasks.writeManifests.mergeConfig({


### PR DESCRIPTION
I have tested this image on Winows, with Hyper-V mode. Here's one scenario:

1. cd to an empty directory
2. run `docker run -it --rm --name spfx-helloworld -v ${PWD}:/usr/app/spfx -p 5432:5432 -p 4321:4321 -p 35729:35729 <IMAGE_NAME> yo @microsoft/sharepoint --solution-name docker-spfx-test02 --component-type webpart --component-name wello-world-webpart --component-description "HelloWorld web part" --is-domain-isolated --framework none --environment spo --skip-feature-deployment false`
3. confirm, entering "y" in the console

Expected output:

```
...
Binary found at /usr/app/spfx/docker-spfx-test02/node_modules/node-sass/vendor/linux-x64-64/binding.node
Testing binary
Binary is fine
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@^1.2.7 (node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN notsup Unsupported engine for watchpack-chokidar2@2.0.0: wanted: {"node":"<8.10.0"} (current: {"node":"10.22.0","npm":"6.14.6"})
npm WARN notsup Not compatible with your version of node/npm: watchpack-chokidar2@2.0.0
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.1.2 (node_modules/watchpack/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN ajv-keywords@3.5.2 requires a peer of ajv@^6.9.1 but none is installed. You must install peer dependencies yourself.
npm WARN uglifyjs-webpack-plugin@0.4.6 requires a peer of webpack@^1.9 || ^2 || ^2.1.0-beta || ^2.2.0-rc || ^3.0.0 but none is installed. You must install peer dependencies yourself.

added 1763 packages from 1055 contributors and audited 1771 packages in 2022.414s

24 packages are looking for funding
  run `npm fund` for details

found 1998 vulnerabilities (1941 low, 13 moderate, 44 high)
  run `npm audit fix` to fix them, or `npm audit` for details

      _=+#####!
   ###########|       .--------------------------------------------.
   ###/    (##|(@)    |              Congratulations!              |
   ###  ######|   \   |  Solution docker-spfx-test-02 is created.  |
   ###/   /###|   (@) |       Run gulp serve to play with it!      |
   #######  ##|   /   '--------------------------------------------'
   ###     /##|(@)
   ###########|
      **=+####!
```

A second scenario:

1. cd to an empty directory
2. run `docker run -it --rm --name spfx-helloworld -v ${PWD}:/usr/app/spfx -p 5432:5432 -p 4321:4321 -p 35729:35729 <IMAGE_NAME>`
3. run `yo @microsoft/sharepoint --solution-name docker-spfx-test02 --component-type webpart --component-name wello-world-webpart --component-description "HelloWorld web part" --is-domain-isolated --framework none --environment spo --skip-feature-deployment false` in the container
4. On the host, make code editings:
- replace `"skipFeatureDeployment": "false"` with `"skipFeatureDeployment": false` (because of SPFx issue https://github.com/SharePoint/sp-dev-docs/issues/3042)
- 2 editings according to this repo README
5. Run in the container:

```
cd docker-spfx-test02
gulp trust-dev-cert
gulp serve
```

6. Run on the host PowerShell:

```
$tcpClient = New-Object -TypeName System.Net.Sockets.TcpClient;
$tcpClient.Connect("localhost", 4321);
$tcpStream = $tcpClient.GetStream();
$callback = { param($sender, $cert, $chain, $errors) return $true };
$sslStream = New-Object -TypeName System.Net.Security.SslStream -ArgumentList @($tcpStream, $true, $callback);
$sslStream.AuthenticateAsClient('');
$certificate = $SslStream.RemoteCertificate;
$x509Certificate = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $certificate
$store = new-object System.Security.Cryptography.X509Certificates.X509Store(
    [System.Security.Cryptography.X509Certificates.StoreName]::Root,
    "localmachine"
)
$store.open("MaxAllowed");
$store.add($x509Certificate);
$store.close();
```

7. Open `https://localhost:5432/workbench` in a browser on the host.

Expected outcome: SPFx workbench with possibility to add the wello-world-webpart web part.