### PR TITLE
chore: upgrade spfx to v1.22.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.16.0
+FROM node:22
 
 EXPOSE 4321 35729
 
@@ -13,7 +13,7 @@ RUN useradd --create-home --shell /bin/bash spfx && \
 
 USER spfx
 
-RUN npm i --location=global gulp-cli@3 yo pnpm
-RUN npm i --location=global @microsoft/generator-sharepoint@1.21.1
+RUN npm i --location=global @rushstack/heft yo pnpm
+RUN npm i --location=global @microsoft/generator-sharepoint@1.22.1
 
 CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ You can also use this image for [Visual Studio development containers](./Develop
 
 ## Available tags
 
-- **latest**: contains the SharePoint Framework Yeoman generator from the [1.21.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.21.1?WT.mc_id=m365-0000-wmastyka) release
-- **online**: contains the SharePoint Framework Yeoman generator from the [1.21.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.21.1?WT.mc_id=m365-0000-wmastyka) release
+- **latest**: contains the SharePoint Framework Yeoman generator from the [1.22.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.22.1?WT.mc_id=m365-0000-wmastyka) release
+- **online**: contains the SharePoint Framework Yeoman generator from the [1.22.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.22.1?WT.mc_id=m365-0000-wmastyka) release
 - **onprem**: contains the SharePoint Framework Yeoman generator from the [1.4.1](https://github.com/sharepoint/sp-dev-docs/wiki/Release-Notes-for-SPFx-Package-Version-1.4.1) release
+- **1.22.1**: contains the SharePoint Framework Yeoman generator from the [1.22](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.22?WT.mc_id=m365-0000-wmastyka) release
+- **1.22**: contains the SharePoint Framework Yeoman generator from the [1.22](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.22?WT.mc_id=m365-0000-wmastyka) release
 - **1.21.1**: contains the SharePoint Framework Yeoman generator from the [1.21.1](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.21.1?WT.mc_id=m365-0000-wmastyka) release
 - **1.21.0**: contains the SharePoint Framework Yeoman generator from the [1.21.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.21?WT.mc_id=m365-0000-wmastyka) release
 - **1.20.0**: contains the SharePoint Framework Yeoman generator from the [1.20.0](https://docs.microsoft.com/sharepoint/dev/spfx/release-1.20?WT.mc_id=m365-0000-wmastyka) release


### PR DESCRIPTION
## Related Issue
fixes  #111

## Notes
- Updates `@microsoft/generator-sharepoint` to `v1.22.1`.
- Replaces `gulp-cli` for `@rushstack/heft` inline with the [SharePoint Framework v1.22.1 release notes](https://learn.microsoft.com/en-gb/sharepoint/dev/spfx/release-1.22.1).

Recommend merging and deploying `v1.22` #110 to Docker Hub as a prerequisite.