### PR TITLE
ci: test docker builds for PRs and pushes on `master`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/.DS_Store
+**/Thumbs.db
+
+.github
+assets

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -52,3 +52,4 @@ jobs:
             ${{ vars.DOCKER_ORG }}/spfx:${{ env.docker_image_tag_name }}
             ${{ vars.DOCKER_ORG }}/spfx:latest
             ${{ vars.DOCKER_ORG }}/spfx:online
+          target: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+        with:
+            cleanup: false
+      - uses: docker/bake-action@v6.10.0
+        with:
+          source: .
+          targets: default
+          push: false
+          set: |
+            *.cache-from=type=gha,scope=dockerspfx
+            *.cache-to=type=gha,scope=dockerspfx,mode=max
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+        with:
+          cleanup: false
+      - uses: docker/bake-action@v6.10.0
+        with:
+          source: .
+          targets: test
+          push: false
+          set: |
+            *.cache-from=type=gha,scope=dockerspfx
+            *.cache-to=type=gha,scope=dockerspfx,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: ci
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:22.16.0
+# ----------------- default (start) -----------------------
+
+FROM node:22.16.0 AS default
 
 EXPOSE 4321 35729
 
@@ -17,3 +19,38 @@ RUN npm i --location=global gulp-cli@3 yo pnpm
 RUN npm i --location=global @microsoft/generator-sharepoint@1.21.1
 
 CMD /bin/bash
+
+# ----------------- default (end) ---------------------------
+
+
+# ----------------- test-base (start) -----------------------
+
+FROM default AS test-base
+
+RUN mkdir -p test/.pnpm-store
+WORKDIR test
+
+# ----------------- test-base (end) -----------------------
+
+
+# ----------------- test-webpart (start) ------------------
+
+FROM test-base AS test-webpart
+
+RUN yo @microsoft/sharepoint --component-type webpart \
+  --solution-name spfx-webpart \
+  --component-name HelloWorld \
+  --framework react \
+  --package-manager pnpm \
+  --skip-install
+
+WORKDIR spfx-webpart
+
+RUN --mount=type=cache,target=/usr/app/spfx/test/.pnpm-store,sharing=locked \
+  pnpm install
+
+RUN pnpm build
+
+WORKDIR ..
+
+# ----------------- test-webpart (end) ------------------

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ You can also use this image for [Visual Studio development containers](./Develop
 - **drop-5**: contains the SharePoint Framework Yeoman generator from the [developer preview drop 5](https://github.com/SharePoint/sp-dev-docs/wiki/Release-Notes-Drop-5)
 - **drop-4**: contains the SharePoint Framework Yeoman generator from the [developer preview drop 4](https://github.com/SharePoint/sp-dev-docs/wiki/Release-Notes-Drop-4-and-MDL2)
 
+### Build
+
+```sh
+docker buildx build . --target default --tag my-spfx
+```
+
+```sh
+cd [your project]
+docker run -it --rm --name ${PWD##*/} -v $PWD:/usr/app/spfx -p 4321:4321 -p 35729:35729 my-spfx
+```
+
 ## Known issues
 
 ### Unable to write files to disk

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,23 @@
+target "default" {
+  target = "default"
+  tags = [
+    "docker.io/m365pnp/spfx:latest",
+    "docker.io/m365pnp/spfx:online"
+  ]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64/v8"
+  ]
+}
+
+
+target "test" {
+  targets = [
+    "test-webpart"
+  ]
+  output = ["type=cacheonly"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64/v8"
+  ]
+}


### PR DESCRIPTION
## Related Issue
fix #116 

## Details

Adds GitHub CI workflow to test docker image builds.

Helps ensure repo changes build and are tested against a sample SPFx project:
- Builds docker image on:
  - `linux/amd64`
  - `linux/arm64/v8`
- Creates and **builds** a sample SPFx react webpart

See example runs: 
- [CalvinTPark/docker-spfx workflow (20881679928)-1
](https://github.com/CalvinTPark/docker-spfx/actions/runs/20881679928/attempts/1)
- [CalvinTPark/docker-spfx workflow (20881679928)-2
](https://github.com/CalvinTPark/docker-spfx/actions/runs/20881679928/attempts/2)
  - Build with docker buildkit cache:
  - <img width="649" height="178" alt="ci.yml with Build -> Test" src="https://github.com/user-attachments/assets/c5599254-b8c2-4348-bc3c-fe6bc1616c7a" />

<details><summary>GitHub Docker Report example (build) [Click to open]</summary>
<p>


<h2>Docker Build summary</h2>
<p>For a detailed look at the build, download the following build record archive and import it into Docker Desktop's Builds view. <br>
Build records include details such as timing, dependencies, results, logs, traces, and other information about a build. <a href="https://www.docker.com/blog/new-beta-feature-deep-dive-into-github-actions-docker-builds-with-docker-desktop/?utm_source=github&utm_medium=actions">Learn more</a></p><p>:arrow_down: <a href="https://github.com/CalvinTPark/docker-spfx/actions/runs/20881679928/artifacts/5085889688"><strong>&#x43;&#x61;&#x6c;&#x76;&#x69;&#x6e;&#x54;&#x50;&#x61;&#x72;&#x6b;&#x7e;&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x2d;&#x73;&#x70;&#x66;&#x78;&#x7e;&#x4e;&#x36;&#x38;&#x32;&#x42;&#x33;&#x2e;&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x62;&#x75;&#x69;&#x6c;&#x64;</strong></a> (36.43 KB - includes <strong>1 build record</strong>)</p><p>Find this useful? <a href="https://docs.docker.com/feedback/gha-build-summary">Let us know</a></p><p><table><tr><th>ID</th><th>Name</th><th>Status</th><th>Cached</th><th>Duration</th></tr><tr><td><code>N682B3</code></td><td><strong>&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x2d;&#x73;&#x70;&#x66;&#x78;&#x20;&#x28;&#x64;&#x65;&#x66;&#x61;&#x75;&#x6c;&#x74;&#x29;</strong></td><td>:white_check_mark: completed</td><td>50%</td><td>2s</td></tr></table>
</p><details><summary><strong>Build inputs</strong></summary><pre lang="yaml"><code>workdir: .
set:
  - '*.cache-from=type=gha,scope=dockerspfx'
  - '*.cache-to=type=gha,scope=dockerspfx,mode=max'
targets:
  - default
</code></pre>
</details><details><summary><strong>Bake definition</strong></summary><pre lang="json"><code>{
  "group": {
    "default": {
      "targets": [
        "default"
      ]
    }
  },
  "target": {
    "default": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "tags": [
        "docker.io/m365pnp/spfx:latest",
        "docker.io/m365pnp/spfx:online"
      ],
      "cache-from": [
        {
          "scope": "dockerspfx",
          "type": "gha"
        }
      ],
      "cache-to": [
        {
          "mode": "max",
          "scope": "dockerspfx",
          "type": "gha"
        }
      ],
      "target": "default",
      "platforms": [
        "linux/amd64",
        "linux/arm64/v8"
      ]
    }
  }
}</code></pre>
</details><hr>

</p>
</details>

<details><summary>GitHub Docker Report example (test) [Click to open]</summary>
<p>

<h2>Docker Build summary</h2>
<p>For a detailed look at the build, download the following build record archive and import it into Docker Desktop's Builds view. <br>
Build records include details such as timing, dependencies, results, logs, traces, and other information about a build. <a href="https://www.docker.com/blog/new-beta-feature-deep-dive-into-github-actions-docker-builds-with-docker-desktop/?utm_source=github&utm_medium=actions">Learn more</a></p><p>:arrow_down: <a href="https://github.com/CalvinTPark/docker-spfx/actions/runs/20881679928/artifacts/5085909411"><strong>&#x43;&#x61;&#x6c;&#x76;&#x69;&#x6e;&#x54;&#x50;&#x61;&#x72;&#x6b;&#x7e;&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x2d;&#x73;&#x70;&#x66;&#x78;&#x7e;&#x30;&#x52;&#x4d;&#x44;&#x58;&#x4b;&#x2e;&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x62;&#x75;&#x69;&#x6c;&#x64;</strong></a> (74.39 KB - includes <strong>1 build record</strong>)</p><p>Find this useful? <a href="https://docs.docker.com/feedback/gha-build-summary">Let us know</a></p><p><table><tr><th>ID</th><th>Name</th><th>Status</th><th>Cached</th><th>Duration</th></tr><tr><td><code>0RMDXK</code></td><td><strong>&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x2d;&#x73;&#x70;&#x66;&#x78;</strong></td><td>:white_check_mark: completed</td><td>27%</td><td>6m21s</td></tr></table>
</p><details><summary><strong>Build inputs</strong></summary><pre lang="yaml"><code>workdir: .
set:
  - '*.cache-from=type=gha,scope=dockerspfx'
  - '*.cache-to=type=gha,scope=dockerspfx,mode=max'
targets:
  - test
</code></pre>
</details><details><summary><strong>Bake definition</strong></summary><pre lang="json"><code>{
  "group": {
    "default": {
      "targets": [
        "test"
      ]
    }
  },
  "target": {
    "test": {
      "context": ".",
      "dockerfile": "Dockerfile",
      "cache-from": [
        {
          "scope": "dockerspfx",
          "type": "gha"
        }
      ],
      "cache-to": [
        {
          "mode": "max",
          "scope": "dockerspfx",
          "type": "gha"
        }
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64/v8"
      ],
      "output": [
        {
          "type": "cacheonly"
        }
      ]
    }
  }
}</code></pre>
</details><hr>


</p>
</details> 

> Potential task: fix the PNPM cache across test runs